### PR TITLE
To fix ">" and "<" marks reversed issue

### DIFF
--- a/dist/sionic.js
+++ b/dist/sionic.js
@@ -387,10 +387,10 @@ function Sionic(mmldata) {
                     this.octave = cmd.val;
                     break;
                 case "<":
-                    this.octave += 1;
+                    this.octave -= 1;
                     break;
                 case ">":
-                    this.octave -= 1;
+                    this.octave += 1;
                     break;
                 case "&":
                     this.tie = true;


### PR DESCRIPTION
Seems that found a bug which the operations of ">" and "<" marks are reversed....
">"と "<"マークの操作が逆になっているバグが見つかりました.... (from google translate)
`
                 		                 
                 case "<":
                     this.octave += 1;
                     break;	
                 case ">":	
                     this.octave -= 1;
                     break;

->'
                 		                 
                 case "<":
                     this.octave -= 1;
                     break;	
                 case ">":	
                     this.octave += 1;
                     break;
                 		                 
